### PR TITLE
🐛 Ensure CI PyPI Package Installations Correspond to Package-Under-Test

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -161,6 +161,35 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+
+      - name: Check Release workflow status
+        id: check
+        run: |
+          output=null
+          while [ "${output}" == null ]; do
+            sleep 10
+            output=$( \
+            curl -sSL -X GET -G \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "branch=${GITHUB_REF_SLUG}" \
+            -d "event=push" \
+            "${WORKFLOW_API_ENDPOINT}" | jq -r '.workflow_runs[0] | "\(.conclusion)"' \
+            )
+          done
+          echo "::set-output name=status::$output"
+        env:
+          # yamllint disable-line rule:line-length
+          WORKFLOW_API_ENDPOINT: https://api.github.com/repos/{{ "${{ github.repository }}" }}/actions/workflows/release.yml/runs
+        shell: bash
+
+      - name: Abort if Release workflow not successful
+        if: "steps.check.outputs.status != 'success'"
+        run: |
+          echo {{ "${{ steps.check.outputs.status }}" }}
+          exit 1
+
       - name: Install package
         run: |
           pip install {{cookiecutter.project_slug}} \

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -72,6 +72,21 @@ jobs:
           password: {{ "${{ secrets.TEST_PYPI_TOKEN }}" }}
           repository_url: https://test.pypi.org/legacy/
 
+      - name: Validate published package is reachable
+        run: |
+          PYPI_PACKAGE="{{cookiecutter.project_slug}}==$(make get-project-version-number)"
+          TEST_PYPI_PACKAGE="${PYPI_PACKAGE} --index-url https://test.pypi.org/simple/"
+          function install_test_pypi() { pip install ${TEST_PYPI_PACKAGE} --no-deps && install_pypi; }
+          function install_pypi() { pip install --upgrade ${PYPI_PACKAGE}; }
+
+          until (install_test_pypi || install_pypi) &> /dev/null
+          do
+             echo "Waiting for Python Package Index to serve current package-under-test"
+             sleep 10
+          done
+          pip list -v
+        shell: bash
+
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5.13.0
         with:


### PR DESCRIPTION
The previous setup had a race condition between the `verify-user-install` CI workflow job installing the latest PyPI package and the `release` Release workflow job uploading the package corresponding to the current commit. This PR synchronizes those jobs, making `verify-user-install` depend on the Release workflow finishing successfully, and adding a `Validate published package is reachable` step to the Release workflow `release` job to ensure that the Release workflow does not finish until the uploaded package can be successfully retrieved on the Python package indexes (note: given the versioning logic, versions are guaranteed to be ascending and, therefore, the latest package will correspond to the package built in the associated CI/CD run). 