### PR TITLE
✨ Make Package Support Conditionally Included

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
   "friendly_name": "{{ cookiecutter.project_slug.replace('-', ' ').title() }}",
   "author": "Teo Zosa",
   "email": "teo@sonosim.com",
+  "project_type": ["package", "project"],
   "jupyter_notebook_support": ["yes", "no"],
   "remote_vcs_host": ["github", "gitlab"],
   "remote_vcs_url": "https://{{ cookiecutter.remote_vcs_host }}.com",

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
         run: |
           make test-mutations
 
+  {% if cookiecutter.project_type == 'package' %}
   # Install Verification ----------------------
 
   verify-user-install:
@@ -284,3 +285,4 @@ jobs:
           {{cookiecutter.project_slug}} --help
           {{cookiecutter.project_slug}} --version
         shell: bash
+  {% endif %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           VERSION=$(make get-project-version-number) &&
           DEV_VERSION="${VERSION}.dev.$(date +%s)" &&
           poetry version "${DEV_VERSION}"
-
+      {%- if cookiecutter.project_type == 'package' %}
       - name: Build package
         run: |
           poetry build --ansi
@@ -97,6 +97,7 @@ jobs:
           pip list -v
         shell: bash
       # yamllint enable rule:line-length
+      {%- endif %}
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5.13.0

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -39,12 +39,14 @@ Requirements
 Table of Contents
 <!-- toc -->
 
+{%- if cookiecutter.project_type == 'package' %}
 Installation
 ============
 You can install {{cookiecutter.friendly_name}} via [pip](https://pip.pypa.io/):
  ```shell script
 pip install {{cookiecutter.project_slug}}
 ```
+{%- endif %}
 
 Usage
 =====
@@ -53,11 +55,14 @@ Usage
 ------------
 - TODO
     - Step 0 description
+
+{%- if cookiecutter.project_type == 'package' %}
 ```python
 import {{cookiecutter.package_name}}
 
 # TODO
 ```
+{%- endif %}
 
 Development
 ===========

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -19,7 +19,9 @@ envlist =
 {%- if cookiecutter.jupyter_notebook_support == 'yes' %}
     nbqaxdoctest,
 {%- endif %}
+{%- if cookiecutter.project_type == 'package' %}
     package
+{%- endif %}
 
 [testenv]
 description = Run test suite under {basepython}
@@ -197,6 +199,7 @@ passenv =
 commands = pre-commit run {posargs} -vv --all-files --color always
            python -c 'print("hint: run `make install-pre-commit-hooks` to add checks as pre-commit hook")'
 
+{%- if cookiecutter.project_type == 'package' %}
 [testenv:package]
 description = Build Python package and validate its long description
 deps =
@@ -206,6 +209,7 @@ deps =
 skip_install = true
 commands = poetry build
            twine check {toxinidir}/dist/*
+{%- endif %}
 
 [testenv:security]
 skip_install = true


### PR DESCRIPTION
Avoid configuration bloat for projects which do not require support to build/deploy the project as a Python package.