### PR TITLE
✨ Add Sentry Exception Monitoring Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Docker Image Build/Push/Deploy Orchestration
 
 Monitoring and Observability
 ----------------------------
+- [Optional] Exception monitoring
+  with [Sentry](https://sentry.io/welcome/)
 - Structured logging
   with [structlog-sentry-logger](https://structlog-sentry-logger.readthedocs.io/en/latest/) (via [structlog](https://www.structlog.org/en/stable/))
     - Granular control flow context logging (via call stack introspection):
@@ -133,8 +135,6 @@ Monitoring and Observability
         - Production: JSON logs
         - Development: Colorized human-readable logs, with JSON logs saved
           locally for retrospective analysis
-    - [Optional] Exception monitoring
-      with [Sentry](https://sentry.io/welcome/)
     - [Optional] Exception logging to Sentry with
       [structlog-sentry](https://www.structlog.org/en/stable/)
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Monitoring and Observability
 ----------------------------
 - [Optional] Exception monitoring
   with [Sentry](https://sentry.io/welcome/)
+  - see: the cookiecutter's [.env]({{cookiecutter.project_slug}}/.env) file for
+    a detailed activation guide
 - Structured logging
   with [structlog-sentry-logger](https://structlog-sentry-logger.readthedocs.io/en/latest/) (via [structlog](https://www.structlog.org/en/stable/))
     - Granular control flow context logging (via call stack introspection):

--- a/{{cookiecutter.project_slug}}/.env
+++ b/{{cookiecutter.project_slug}}/.env
@@ -8,6 +8,12 @@
 #
 # DO NOT ADD THIS FILE TO VERSION CONTROL!
 
-# see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+# If you wish to enable Sentry exception monitoring for your application,
+# sign up at https://sentry.io/signup/, create a new Sentry project for your
+# application, and fill in the `SENTRY_DSN` field with your project-specific
+# Data Source Name (DSN). The Sentry client will be automatically initialized
+# with this DSN by the code in the application's `__init__.py` upon each
+# application startup.
+#   See Also: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
 SENTRY_DSN=
 CI_ENVIRONMENT_SLUG=dev-local

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -35,6 +35,7 @@ python-dotenv = "^0.15.0"
 typer = {extras = ["all"], version = "^0.3.2"}
 
 # Monitoring and Observability
+sentry-sdk = "^1.1.0"
 structlog-sentry-logger = "^0.7.3"
 
 # Type Checking and Data Validation

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/__init__.py
@@ -1,4 +1,11 @@
 """{{cookiecutter.friendly_name}}."""
 from typing import List
 
+import sentry_sdk
+from dotenv import find_dotenv, load_dotenv
+
 __all__: List[str] = []
+
+load_dotenv(find_dotenv())
+# Note: if DSN isn't defined, will silently not transmit telemetry
+sentry_sdk.init()  # pylint: disable=abstract-class-instantiated


### PR DESCRIPTION
Adds optional [Sentry](https://sentry.io/welcome/) exception monitoring support as a distinct feature (previously provided by proxy through `structlog-sentry-logger`). 