### PR TITLE
✨ Add Automated Docker Image CI/CD Build/Push Feature

### DIFF
--- a/.github/workflows/reset-instance.yml
+++ b/.github/workflows/reset-instance.yml
@@ -75,6 +75,17 @@ jobs:
             pre-commit run "${hook}" -vv --all-files --color always || true
           done
 
+      - name: Install Poetry
+        working-directory: ${{ env.COOKIECUTTER_PROJECT_INSTANCE }}
+        run: |
+          pip install --constraint="${PIP_CONSTRAINTS_FILE}" poetry
+          poetry --version
+
+      - name: Add poetry lockfile for ${{ env.COOKIECUTTER_PROJECT_INSTANCE }}
+        working-directory: ${{ env.COOKIECUTTER_PROJECT_INSTANCE }}
+        run: |
+          poetry update --lock
+
       - name: Create commit
         run: |
           cd "${COOKIECUTTER_META_PROJECT}"

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ CI/CD
 -----
 - Continuous integration
   with [`GitHub Actions`](https://github.com/features/actions)
+- Automated Docker image builds and pushes
+  to [Docker Hub](https://hub.docker.com/)
 - Automated uploads
   to [PyPI](https://pypi.org/)
   and [TestPyPI](https://test.pypi.org/)[*](#conditional-rendering)

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -106,3 +106,42 @@ jobs:
           tag: {{ "${{ steps.check-version.outputs.tag }}" }}
         env:
           GITHUB_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
+
+# Docker build/push job ----------------------
+  docker:
+    name: Docker Build/Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: 2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: {{ "${{ secrets.DOCKERHUB_USERNAME }}" }}
+          password: {{ "${{ secrets.DOCKERHUB_TOKEN }}" }}
+
+      # yamllint disable rule:line-length
+      - name: Get container image metadata
+        id: container-image-metadata
+        run: |
+          echo "::set-output name=tagged_images::$(make docker-repository-tagged-images | tr '\n' ',')"
+
+      - name: Build and push container image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: {{ "${{ steps.container-image-metadata.outputs.tagged_images }}" }}
+      # yamllint enable rule:line-length
+
+      - name: Log image digest
+        run: echo {{ "${{ steps.docker_build.outputs.digest }}" }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Get container image metadata
         id: container-image-metadata
         run: |
-          echo "::set-output name=tagged_images::$(make docker-repository-tagged-images | tr '\n' ',')"
+          echo "::set-output name=tagged_images::$(make get-make-var-IMG get-make-var-LATEST_IMG | tr '\n' ',')"
 
       - name: Build and push container image
         id: docker_build

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -99,24 +99,7 @@ jobs:
       # yamllint enable rule:line-length
       {%- endif %}
 
-      - name: Publish the release notes
-        uses: release-drafter/release-drafter@v5.13.0
-        with:
-          publish: {{ "${{ steps.check-version.outputs.tag != '' }}" }}
-          tag: {{ "${{ steps.check-version.outputs.tag }}" }}
-        env:
-          GITHUB_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
-
-# Docker build/push job ----------------------
-  docker:
-    name: Docker Build/Push
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2.3.3
-        with:
-          fetch-depth: 2
-
+      # Docker build/push job ----------------------
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -133,7 +116,9 @@ jobs:
       - name: Get container image metadata
         id: container-image-metadata
         run: |
-          echo "::set-output name=tagged_images::$(make get-make-var-IMG get-make-var-LATEST_IMG | tr '\n' ',')"
+          CI_TAGGED_IMG=$(echo -n $(make get-make-var-IMG get-project-version-number) | tr ' ' '-')
+          CANONICAL_TAGGED_IMGS=$(echo -n $(make get-make-var-IMG get-make-var-LATEST_IMG) | tr ' ' ',')
+          echo "::set-output name=tagged_images::${CI_TAGGED_IMG},${CANONICAL_TAGGED_IMGS}"
 
       - name: Build and push container image
         id: docker_build
@@ -145,3 +130,12 @@ jobs:
 
       - name: Log image digest
         run: echo {{ "${{ steps.docker_build.outputs.digest }}" }}
+
+      # Release notes publication ----------------------
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v5.13.0
+        with:
+          publish: {{ "${{ steps.check-version.outputs.tag != '' }}" }}
+          tag: {{ "${{ steps.check-version.outputs.tag }}" }}
+        env:
+          GITHUB_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -59,6 +59,11 @@ validate_req_env_vars:
 	$(call check_defined, REQ_ENV_VARS, Error: Required list of env vars to validate as defined not set!)
 	$(foreach REQ_ENV_VAR,$(REQ_ENV_VARS),$(call check_defined, $(REQ_ENV_VAR), Error: Required env var not set!))
 
+.PHONY: docker-repository-tagged-images
+docker-repository-tagged-images:
+	@echo $(IMG)
+	@echo $(LATEST_IMG)
+
 .PHONY: strong-version-tag
 strong-version-tag:
 	@echo $(TAG)

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -63,11 +63,6 @@ validate_req_env_vars:
 	$(call check_defined, REQ_ENV_VARS, Error: Required list of env vars to validate as defined not set!)
 	$(foreach REQ_ENV_VAR,$(REQ_ENV_VARS),$(call check_defined, $(REQ_ENV_VAR), Error: Required env var not set!))
 
-.PHONY: docker-repository-tagged-images
-docker-repository-tagged-images:
-	@echo $(IMG)
-	@echo $(LATEST_IMG)
-
 .PHONY: strong-version-tag
 strong-version-tag:
 	@echo $(TAG)

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -41,6 +41,10 @@ LATEST_IMG := $(DOCKER_REPOSITORY):latest
 # HELPER TARGETS                                                                #
 #################################################################################
 
+.PHONY: get-make-var-%
+get-make-var-%:
+	@echo $($*)
+
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.
 #


### PR DESCRIPTION
This PR adds automated Docker image build/push CI/CD functionality to the Release workflow. 

- In addition to canonical project tags (viz. Makefile-generated tags) which are enforced for local development, a CI-generated tag is also applied; this tag is synchronized with other Release workflow artifacts' versioning for maximum image provenance.