### PR TITLE
👷 Make Separate Dependabot Trunk Push Check Workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,15 @@
 name: Auto-Merge-Dependabot
 
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
+  workflow_run:
+    workflows:
+      # Upstream workflow runs on PRs to main/master and always completes;
+      # needed because Dependabot-initiated pushes to master do not have access
+      # to repository secrets on which this workflow relies.
+      # see: dependabot/dependabot-core/issues/3253
+      - Dependabot PR Check
+    types:
+      - completed
 
 jobs:
   auto-merge:

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,18 @@
+---
+# Needed because Dependabot-initiated pushes to master do not have access
+# to repository secrets on which downstream workflows rely.
+# see: dependabot/dependabot-core/issues/3253
+name: Dependabot PR Check
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main  # forward-compatibility with new GitHub default branch naming
+      - master  # backward-compatibility with old GitHub default branch naming
+
+jobs:
+  check_dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "PR created by Dependabot"

--- a/.github/workflows/dependabot_trunk_push.yml
+++ b/.github/workflows/dependabot_trunk_push.yml
@@ -2,7 +2,7 @@
 # Needed because Dependabot-initiated pushes to master do not have access
 # to repository secrets on which downstream workflows rely.
 # see: dependabot/dependabot-core/issues/3253
-name: Dependabot PR Check
+name: Dependabot Trunk Push Check
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - run: echo "PR created by Dependabot"
+      - run: echo "Push (merge) to trunk initiated by Dependabot"

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
-      - Dependabot PR Check
+      - Dependabot Trunk Push Check
     types:
       - completed
 

--- a/.github/workflows/publish_log4brains.yml
+++ b/.github/workflows/publish_log4brains.yml
@@ -7,9 +7,10 @@ on:  # yamllint disable-line rule:truthy
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
-      - Dependabot PR Check
+      - Dependabot Trunk Push Check
     types:
       - completed
+
 env:
   BUILD_DIR: .log4brains/out
 

--- a/.github/workflows/reset-instance.yml
+++ b/.github/workflows/reset-instance.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
-      - Dependabot PR Check
+      - Dependabot Trunk Push Check
     types:
       - completed
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/auto-merge-dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,15 @@
 name: Auto-Merge-Dependabot
 
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
+  workflow_run:
+    workflows:
+      # Upstream workflow runs on PRs to main/master and always completes;
+      # needed because Dependabot-initiated pushes to master do not have access
+      # to repository secrets on which this workflow relies.
+      # see: dependabot/dependabot-core/issues/3253
+      - Dependabot PR Check
+    types:
+      - completed
 
 jobs:
   auto-merge:

--- a/{{cookiecutter.project_slug}}/.github/workflows/dependabot_pr.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,19 @@
+---
+# Needed because Dependabot-initiated pushes to master do not have access
+# to repository secrets on which downstream workflows rely.
+# see: dependabot/dependabot-core/issues/3253
+name: Dependabot PR Check
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main  # forward-compatibility with new GitHub default branch naming
+      - master  # backward-compatibility with old GitHub default branch naming
+
+jobs:
+  check_dependabot:
+    runs-on: ubuntu-latest
+    # yamllint disable-line rule:braces
+    if: {{ "${{ github.actor == 'dependabot[bot]' }}" }}
+    steps:
+      - run: echo "PR created by Dependabot"

--- a/{{cookiecutter.project_slug}}/.github/workflows/dependabot_trunk_push.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/dependabot_trunk_push.yml
@@ -2,7 +2,7 @@
 # Needed because Dependabot-initiated pushes to master do not have access
 # to repository secrets on which downstream workflows rely.
 # see: dependabot/dependabot-core/issues/3253
-name: Dependabot PR Check
+name: Dependabot Trunk Push Check
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -16,4 +16,4 @@ jobs:
     # yamllint disable-line rule:braces
     if: {{ "${{ github.actor == 'dependabot[bot]' }}" }}
     steps:
-      - run: echo "PR created by Dependabot"
+      - run: echo "Push (merge) to trunk initiated by Dependabot"

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
-      - Dependabot PR Check
+      - Dependabot Trunk Push Check
     types:
       - completed
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish_log4brains.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish_log4brains.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
-      - Dependabot PR Check
+      - Dependabot Trunk Push Check
     types:
       - completed
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
-      - Dependabot PR Check
+      - Dependabot Trunk Push Check
     types:
       - completed
   pull_request:

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -4,17 +4,14 @@ name: Release
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows:
-      # Upstream workflow runs on pushes to main/master and always completes;
+      # Upstream workflow runs on pushes/PRs to main/master and always completes;
       # needed because Dependabot-initiated pushes to master do not have access
       # to repository secrets on which this workflow relies.
       # see: dependabot/dependabot-core/issues/3253
       - Dependabot Trunk Push Check
+      - Dependabot PR Check
     types:
       - completed
-  pull_request:
-    branches:
-      - main  # forward-compatibility with new GitHub default branch naming
-      - master  # backward-compatibility with old GitHub default branch naming
 
 jobs:
   release:


### PR DESCRIPTION
To allow runs on both pushes and PRs to the trunk branch (i.e., main/master).