### PR TITLE
🐛 📋 Fix Sphinx AutoAPI Top-Level Section Header Rendering

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/source/_templates/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/index.rst
@@ -1,0 +1,11 @@
+API Reference
+=============
+
+.. toctree::
+   :titlesonly:
+
+   {% for page in pages %}
+   {% if page.top_level_object and page.display %}
+   {{ page.include_path }}
+   {% endif %}
+   {% endfor %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/attribute.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/attribute.rst
@@ -1,0 +1,1 @@
+{% extends "python/data.rst" %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/class.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/class.rst
@@ -1,0 +1,50 @@
+{% if obj.display %}
+.. py:{{ obj.type }}:: {{ obj.short_name }}{% if obj.args %}({{ obj.args }}){% endif %}
+{% for (args, return_annotation) in obj.overloads %}
+   {{ " " * (obj.type | length) }}   {{ obj.short_name }}{% if args %}({{ args }}){% endif %}
+{% endfor %}
+
+
+   {% if obj.bases %}
+   {% if "show-inheritance" in autoapi_options %}
+   Bases: {% for base in obj.bases %}{{ base|link_objs }}{% if not loop.last %}, {% endif %}{% endfor %}
+   {% endif %}
+
+
+   {% if "show-inheritance-diagram" in autoapi_options and obj.bases != ["object"] %}
+   .. autoapi-inheritance-diagram:: {{ obj.obj["full_name"] }}
+      :parts: 1
+      {% if "private-members" in autoapi_options %}
+      :private-bases:
+      {% endif %}
+
+   {% endif %}
+   {% endif %}
+   {% if obj.docstring %}
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_classes = obj.classes|selectattr("display")|list %}
+   {% else %}
+   {% set visible_classes = obj.classes|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for klass in visible_classes %}
+   {{ klass.render()|indent(3) }}
+   {% endfor %}
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_attributes = obj.attributes|selectattr("display")|list %}
+   {% else %}
+   {% set visible_attributes = obj.attributes|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for attribute in visible_attributes %}
+   {{ attribute.render()|indent(3) }}
+   {% endfor %}
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_methods = obj.methods|selectattr("display")|list %}
+   {% else %}
+   {% set visible_methods = obj.methods|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for method in visible_methods %}
+   {{ method.render()|indent(3) }}
+   {% endfor %}
+{% endif %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/data.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/data.rst
@@ -1,0 +1,32 @@
+{% if obj.display %}
+.. py:{{ obj.type }}:: {{ obj.name }}
+   {%+ if obj.value is not none or obj.annotation is not none -%}
+   :annotation:
+        {%- if obj.annotation %} :{{ obj.annotation }}
+        {%- endif %}
+        {%- if obj.value is not none %} = {%
+            if obj.value is string and obj.value.splitlines()|count > 1 -%}
+                Multiline-String
+
+    .. raw:: html
+
+        <details><summary>Show Value</summary>
+
+    .. code-block:: text
+        :linenos:
+
+        {{ obj.value|indent(width=8) }}
+
+    .. raw:: html
+
+        </details>
+
+            {%- else -%}
+                {{ obj.value|string|truncate(100) }}
+            {%- endif %}
+        {%- endif %}
+    {% endif %}
+
+
+   {{ obj.docstring|indent(3) }}
+{% endif %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/exception.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/exception.rst
@@ -1,0 +1,1 @@
+{% extends "python/class.rst" %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/function.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/function.rst
@@ -1,0 +1,18 @@
+{% if obj.display %}
+.. py:function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
+
+{% for (args, return_annotation) in obj.overloads %}
+              {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+
+{% endfor %}
+   {% if sphinx_version >= (2, 1) %}
+   {% for property in obj.properties %}
+   :{{ property }}:
+   {% endfor %}
+   {% endif %}
+
+   {% if obj.docstring %}
+   {{ obj.docstring|indent(3) }}
+   {% else %}
+   {% endif %}
+{% endif %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/method.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/method.rst
@@ -1,0 +1,27 @@
+{%- if obj.display %}
+{% if sphinx_version >= (2, 1) %}
+.. py:method:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
+
+{% for (args, return_annotation) in obj.overloads %}
+            {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+
+{% endfor %}
+   {% if obj.properties %}
+   {% for property in obj.properties %}
+   :{{ property }}:
+   {% endfor %}
+
+   {% else %}
+
+   {% endif %}
+{% else %}
+.. py:{{ obj.method_type }}:: {{ obj.short_name }}({{ obj.args }})
+{% for (args, return_annotation) in obj.overloads %}
+   {{ " " * (obj.method_type | length) }}   {{ obj.short_name }}({{ args }})
+{% endfor %}
+
+{% endif %}
+   {% if obj.docstring %}
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/module.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/module.rst
@@ -1,0 +1,114 @@
+{% if not obj.display %}
+:orphan:
+
+{% endif %}
+:py:mod:`{{ obj.name }}`
+=========={{ "=" * obj.name|length }}
+
+.. py:module:: {{ obj.name }}
+
+{% if obj.docstring %}
+.. autoapi-nested-parse::
+
+   {{ obj.docstring|indent(3) }}
+
+{% endif %}
+
+{% block subpackages %}
+{% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
+{% if visible_subpackages %}
+Subpackages
+-----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 3
+
+{% for subpackage in visible_subpackages %}
+   {{ subpackage.short_name }}/index.rst
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+{% block submodules %}
+{% set visible_submodules = obj.submodules|selectattr("display")|list %}
+{% if visible_submodules %}
+Submodules
+----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+{% for submodule in visible_submodules %}
+   {{ submodule.short_name }}/index.rst
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+{% block content %}
+{% if obj.all is not none %}
+{% set visible_children = obj.children|selectattr("short_name", "in", obj.all)|list %}
+{% elif obj.type is equalto("package") %}
+{% set visible_children = obj.children|selectattr("display")|list %}
+{% else %}
+{% set visible_children = obj.children|selectattr("display")|rejectattr("imported")|list %}
+{% endif %}
+{% if visible_children %}
+{{ obj.type|title }} Contents
+{{ "-" * obj.type|length }}---------
+
+{% set visible_classes = visible_children|selectattr("type", "equalto", "class")|list %}
+{% set visible_functions = visible_children|selectattr("type", "equalto", "function")|list %}
+{% set visible_attributes = visible_children|selectattr("type", "equalto", "data")|list %}
+{% if "show-module-summary" in autoapi_options and (visible_classes or visible_functions) %}
+{% block classes scoped %}
+{% if visible_classes %}
+Classes
+~~~~~~~
+
+.. autoapisummary::
+
+{% for klass in visible_classes %}
+   {{ klass.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+
+{% block functions scoped %}
+{% if visible_functions %}
+Functions
+~~~~~~~~~
+
+.. autoapisummary::
+
+{% for function in visible_functions %}
+   {{ function.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+
+{% block attributes scoped %}
+{% if visible_attributes %}
+Attributes
+~~~~~~~~~~
+
+.. autoapisummary::
+
+{% for attribute in visible_attributes %}
+   {{ attribute.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+{% endif %}
+{% for obj_item in visible_children %}
+{{ obj_item.render()|indent(0) }}
+{% endfor %}
+{% endif %}
+{% endblock %}

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/module.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/module.rst
@@ -2,6 +2,11 @@
 :orphan:
 
 {% endif %}
+
+=======================================================================================================
+PLACEHOLDER THAT WILL BE EATEN BY SPHINX (note: purposely broken across two lines)
+see: https://stackoverflow.com/questions/27965192/python-sphinx-skips-first-section-when-generating-pdf
+
 :py:mod:`{{ obj.name }}`
 =========={{ "=" * obj.name|length }}
 

--- a/{{cookiecutter.project_slug}}/docs/source/_templates/python/package.rst
+++ b/{{cookiecutter.project_slug}}/docs/source/_templates/python/package.rst
@@ -1,0 +1,1 @@
+{% extends "python/module.rst" %}

--- a/{{cookiecutter.project_slug}}/docs/source/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/source/conf.py
@@ -104,7 +104,7 @@ autoapi_options = [
 ]
 autoapi_python_class_content = "both"  # Concatenate __init__ and class docstrings
 autoapi_python_use_implicit_namespaces = True  # APIDOC config
-# autoapi_template_dir = "_templates"
+autoapi_template_dir = "_templates"
 autoapi_type = "python"
 autodoc_typehints = "description"  # Show typehints as content of function or method
 


### PR DESCRIPTION
A known but obscure issue when using Sphinx is that top-level section headers are swallowed. This PR introduces a hacky fix to address this issue.

See: readthedocs/sphinx-autoapi#302