### PR TITLE
👽 Use Latest structlog-sentry-logger Features

### DIFF
--- a/{{cookiecutter.project_slug}}/.env
+++ b/{{cookiecutter.project_slug}}/.env
@@ -16,4 +16,5 @@
 # application startup.
 #   See Also: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
 SENTRY_DSN=
-CI_ENVIRONMENT_SLUG=dev-local
+STRUCTLOG_SENTRY_LOGGER_CLOUD_LOGGING_COMPATIBILITY_MODE_ON=
+STRUCTLOG_SENTRY_LOGGER_LOCAL_DEVELOPMENT_LOGGING_MODE_ON=

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -37,7 +37,7 @@ python = "^3.7"
 
 # Monitoring and Observability
 sentry-sdk = "^1.1.0"
-structlog-sentry-logger = "^0.9.0"
+structlog-sentry-logger = "^0.11.0"
 
 {%- if cookiecutter.jupyter_notebook_project != 'no' %}
 # Jupyter Notebook


### PR DESCRIPTION
Namely, enabling Cloud Logging compatibility by default and renaming the env var which enables pretty printing.

see:
- TeoZosa/structlog-sentry-logger#285
- TeoZosa/structlog-sentry-logger#289