### PR TITLE
🔧 Update Poetry Install Step

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -21,7 +21,7 @@ ENV POETRY_HOME=/opt/poetry \
     POETRY_VIRTUALENVS_CREATE=false
 ENV PATH="${POETRY_HOME}/bin:${PATH}"
 # Install `poetry` via `curl` and system `python`
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && \
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python && \
     poetry --version && \
     poetry config --list
 {% if cookiecutter.jupyter_notebook_project == 'yes' %}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -77,7 +77,7 @@ ifeq ($(shell command -v poetry),)
 	@echo "poetry could not be found!"
 	@echo "Please install poetry!"
 	@echo "Ex.: 'curl -sSL \
-	https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python - \
+	https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py  | python - \
 	&& source $$HOME/.local/env'"
 	@echo "see:"
 	@echo "- https://python-poetry.org/docs/#installation"


### PR DESCRIPTION
From [Poetry: Installation](https://python-poetry.org/docs/#installation):

```
The get-poetry.py script described here will be replaced in Poetry 1.2
by install-poetry.py. From Poetry 1.1.7 onwards, you can already use
this script as described here.
```