### PR TITLE
➖ Drop Python 3.7 support

### DIFF
--- a/.github/CONTRIBUTING_GUIDE.rst
+++ b/.github/CONTRIBUTING_GUIDE.rst
@@ -51,7 +51,7 @@ How to set up your development environment
    Invoking ``make`` without any arguments will display
    auto-generated documentation on available commands.
 
-Make sure you have Python 3.7+ and Poetry_ installed and configured.
+Make sure you have Python 3.8+ and Poetry_ installed and configured.
 
 Install the package with development requirements:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         library-type: ["pure_python"]
 
     name: icontract benchmarks for Python ${{ matrix.python-version }} (${{ matrix.os }})  [${{ matrix.library-type }}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters = true
 isolated_build = true
 envlist =
-    py3{7,8,9}
+    py3{8,9}
 
 [base_configs]
 wheel = false
@@ -28,7 +28,7 @@ commands = pytest \
 wheel = {[base_configs]wheel}
 parallel_show_output = {[base_configs]parallel_show_output}
 
-[testenv:py3{7,8,9}-benchmark-{pure_python}]
+[testenv:py3{8,9}-benchmark-{pure_python}]
 description = Run performance testing under {basepython}
 setenv =
     {[testenv]setenv}

--- a/{{cookiecutter.project_slug}}/.github/CONTRIBUTING_GUIDE.rst
+++ b/{{cookiecutter.project_slug}}/.github/CONTRIBUTING_GUIDE.rst
@@ -51,7 +51,7 @@ How to set up your development environment
    Invoking ``make`` without any arguments will display
    auto-generated documentation on available commands.
 
-Make sure you have Python 3.7+ and Poetry_ installed and configured.
+Make sure you have Python 3.8+ and Poetry_ installed and configured.
 
 Install the package with development requirements:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,12 +110,12 @@ Lint the code:
    prior to every commit that is pushed.
 
 You can also run a specific Python ``tox`` testenv.
-For example, invoke the Python3.7 unit test suite like this:
+For example, invoke the Python3.8 unit test suite like this:
 
 .. highlight:: bash
 .. code-block:: bash
 
-   $ make test-py37
+   $ make test-py38
 
 Unit tests are located in the ``tests`` directory,
 and are written using the pytest_ testing framework.

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     name: Python {{ "${{ matrix.python-version }}" }} ({{ "${{ matrix.os }}" }})
     runs-on: {{ "${{ matrix.os }}" }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         library-type: ["pure_python", "c_library"]
 
     name: Performance testing for Python {{ "${{ matrix.python-version }}" }}  ({{ "${{ matrix.os }}" }})  [{{ "${{ matrix.library-type }}" }}]

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     name: Package build
     runs-on: {{ "${{ matrix.os }}" }}
@@ -199,7 +199,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     name: Verify package install as user
     runs-on: {{ "${{ matrix.os }}" }}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -279,7 +279,7 @@ performance-benchmarks:
 .PHONY: performance-benchmarks-%
 # Run library-specific (viz. Python or C) performance benchmark tests
 performance-benchmarks-%:
-	$(MAKE) tox-"py3{7,8,9}-benchmark-$*"
+	$(MAKE) tox-"py3{8,9}-benchmark-$*"
 
 # Mutation testing modifies the code in small ways that should produce incorrect semantics
 # If a test suite is sufficiently strong, this "mutated" code should caught by the suite,

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -150,7 +150,7 @@ encapsulated in single [Make](https://www.gnu.org/software/make/) targets.
 :building_construction: Package and Dependencies Installation
 -------------------------------------------------------------
 
-Make sure you have Python 3.7+ and [`poetry`](https://python-poetry.org/)
+Make sure you have Python 3.8+ and [`poetry`](https://python-poetry.org/)
 installed and configured.
 
 To install the package and all dev dependencies, run:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -33,7 +32,7 @@ generate-setup-file = true
 Changelog = "{{ cookiecutter.project_repository_url }}/releases"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 
 # Monitoring and Observability
 sentry-sdk = "^1.5.6"
@@ -73,7 +72,7 @@ importlib-metadata = "^4.11.1"
 rich = "^11.2.0"
 typer = {extras = ["all"], version = "^0.4.0"}
 {%- else %}
-numpy = "^1.22.2"
+numpy = "^1.22.3"
 pandas = "^1.4.1"
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,15 +1,12 @@
 [gh-actions]
 python =
 {%- if cookiecutter.jupyter_notebook_project == 'yes' %}
-    3.7: nbqaxdoctest
     3.8: nbqaxdoctest
     3.9: nbqaxdoctest
 {%- elif cookiecutter.jupyter_notebook_project == 'hybrid' %}
-    3.7: py37, c_library, nbqaxdoctest
     3.8: py38, c_library, nbqaxdoctest
     3.9: py39, c_library, coverage, nbqaxdoctest
 {%- else %}
-    3.7: py37, c_library
     3.8: py38, c_library
     3.9: py39, c_library, coverage
 {%- endif %}
@@ -19,7 +16,7 @@ skip_missing_interpreters = true
 isolated_build = true
 envlist =
 {%- if cookiecutter.jupyter_notebook_project != 'yes' %}
-    py3{7,8,9},
+    py3{8,9},
     c_library,
     coverage,
 {%- endif %}
@@ -69,7 +66,7 @@ commands = {[testenv]commands}
 wheel = true
 parallel_show_output = {[testenv]parallel_show_output}
 
-[testenv:py3{7,8,9}-benchmark-{pure_python,c_library}]
+[testenv:py3{8,9}-benchmark-{pure_python,c_library}]
 description = Run performance testing under {basepython}
 setenv =
     {[testenv]setenv}
@@ -178,7 +175,7 @@ commands =
         --compare-branch={env:DIFF_AGAINST:origin/master} \
         --diff-range-notation '..'
 depends =
-    py3{7,8,9}
+    py3{8,9}
 parallel_show_output = {[testenv]parallel_show_output}
 {%- endif %}
 
@@ -204,7 +201,7 @@ commands =
         exit $\{FAILURE_EXIT_CODES:0:1\}'
 # Run after testenv since auto-generated temp `.py` files interfere with pytest
 depends =
-    py3{7,8,9}
+    py3{8,9}
 wheel = {[base_configs]wheel}
 parallel_show_output = {[base_configs]parallel_show_output}
 {%- endif %}


### PR DESCRIPTION
## What
SSIA.

## Why
Even though 3.7 isn't EOL until 27 Jun 2023, dropping 3.7 simplifies maintenance, projects on M1 macs, etc.