### PR TITLE
👷  Use Poetry dependency groups for docs dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,8 +2,8 @@
 name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -70,8 +70,8 @@ tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy"
 name = "babel"
 version = "2.9.1"
 description = "Internationalization utilities"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
@@ -255,16 +255,16 @@ python-versions = "*"
 name = "docutils"
 version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "emoji"
 version = "1.7.0"
 description = "Emoji for Python"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [package.extras]
@@ -393,8 +393,8 @@ python-versions = ">=3.5"
 name = "imagesize"
 version = "1.3.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -473,8 +473,8 @@ python-versions = ">=3.6"
 name = "markdown-it-py"
 version = "2.0.1"
 description = "Python port of markdown-it. Markdown parsing, done right!"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
@@ -510,8 +510,8 @@ python-versions = "*"
 name = "mdit-py-plugins"
 version = "0.3.0"
 description = "Collection of plugins for markdown-it-py"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
@@ -526,8 +526,8 @@ testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 name = "mdurl"
 version = "0.1.0"
 description = "Markdown URL utilities"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -560,8 +560,8 @@ python-versions = "*"
 name = "myst-parser"
 version = "0.18.0"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -577,7 +577,7 @@ typing-extensions = "*"
 code_style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
-testing = ["beautifulsoup4", "coverage", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
+testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
 
 [[package]]
 name = "nodeenv"
@@ -599,7 +599,7 @@ python-versions = ">=3.7"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -618,8 +618,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 name = "pbr"
 version = "5.8.1"
 description = "Python Build Reasonableness"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.6"
 
 [[package]]
@@ -716,7 +716,7 @@ testutils = ["gitpython (>3)"]
 name = "pyparsing"
 version = "3.0.7"
 description = "Python parsing module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -884,8 +884,8 @@ unidecode = ["Unidecode (>=1.1.1)"]
 name = "pytz"
 version = "2021.3"
 description = "World timezone definitions, modern and historical"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -988,8 +988,8 @@ python-versions = ">=3.6"
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -1004,8 +1004,8 @@ python-versions = "*"
 name = "sphinx"
 version = "5.1.1"
 description = "Python documentation generator"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -1036,8 +1036,8 @@ test = ["cython", "html5lib", "pytest (>=4.6)", "typed-ast"]
 name = "sphinx-autodoc-typehints"
 version = "1.19.1"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1051,8 +1051,8 @@ type_comments = ["typed-ast (>=1.5.2)"]
 name = "sphinx-rtd-theme"
 version = "1.0.0"
 description = "Read the Docs theme for Sphinx"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [package.dependencies]
@@ -1066,8 +1066,8 @@ dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client"]
 name = "sphinxcontrib-apidoc"
 version = "0.3.0"
 description = "A Sphinx extension for running 'sphinx-apidoc' on each build"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -1078,8 +1078,8 @@ Sphinx = ">=1.6.0"
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1090,8 +1090,8 @@ test = ["pytest"]
 name = "sphinxcontrib-confluencebuilder"
 version = "1.9.0"
 description = "Sphinx extension to build Atlassian Confluence Storage Markup"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7"
 
 [package.dependencies]
@@ -1102,8 +1102,8 @@ sphinx = ">=1.8"
 name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1114,8 +1114,8 @@ test = ["pytest"]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.extras]
@@ -1126,8 +1126,8 @@ test = ["html5lib", "pytest"]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1137,8 +1137,8 @@ test = ["flake8", "mypy", "pytest"]
 name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1149,8 +1149,8 @@ test = ["pytest"]
 name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1166,9 +1166,9 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-dev = ["cogapp", "coverage", "freezegun (>=0.2.8)", "furo", "pre-commit", "pretend", "pytest (>=6.0)", "pytest-asyncio", "rich", "simplejson", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "tomli", "twisted"]
+dev = ["cogapp", "coverage[toml]", "freezegun (>=0.2.8)", "furo", "pre-commit", "pretend", "pytest (>=6.0)", "pytest-asyncio", "rich", "simplejson", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "tomli", "twisted"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
-tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio", "simplejson"]
+tests = ["coverage[toml]", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio", "simplejson"]
 
 [[package]]
 name = "structlog-sentry-logger"
@@ -1276,15 +1276,15 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=5.2,<6.0)", "isort (>=5.0.6,<6.
 name = "types-emoji"
 version = "1.7.1"
 description = "Typing stubs for emoji"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
 version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -1339,11 +1339,11 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4"
 six = "*"
 
 [package.extras]
-all = ["attrs", "cmake", "codecov", "colorama", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipython", "ipython", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert", "ninja", "pybind11", "pygments", "pygments", "pytest", "pytest", "pytest", "pytest", "pytest", "pytest", "pytest-cov", "pytest-cov", "pytest-cov", "pytest-cov", "scikit-build", "six", "typing"]
+all = ["IPython", "IPython", "Pygments", "Pygments", "attrs", "cmake", "codecov", "colorama", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert", "ninja", "pybind11", "pytest", "pytest", "pytest", "pytest", "pytest", "pytest", "pytest-cov", "pytest-cov", "pytest-cov", "pytest-cov", "scikit-build", "six", "typing"]
 all-strict = ["IPython (==7.10.0)", "IPython (==7.23.1)", "Pygments (==2.0.0)", "Pygments (==2.4.1)", "attrs (==19.2.0)", "cmake (==3.21.2)", "codecov (==2.0.15)", "colorama (==0.4.1)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.3.0)", "debugpy (==1.6.0)", "ipykernel (==5.2.0)", "ipykernel (==6.0.0)", "ipython-genutils (==0.2.0)", "jedi (==0.16)", "jinja2 (==3.0.0)", "jupyter-client (==6.1.5)", "jupyter-client (==7.0.0)", "jupyter-core (==4.7.0)", "nbconvert (==6.0.0)", "ninja (==1.10.2)", "pybind11 (==2.7.1)", "pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==6.2.5)", "pytest-cov (==2.8.1)", "pytest-cov (==2.8.1)", "pytest-cov (==2.9.0)", "pytest-cov (==3.0.0)", "scikit-build (==0.11.1)", "six (==1.11.0)", "typing (==3.7.4)"]
-colors = ["colorama", "pygments", "pygments"]
-jupyter = ["attrs", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipython", "ipython", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert"]
-optional = ["attrs", "colorama", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipython", "ipython", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert", "pygments", "pygments", "tomli"]
+colors = ["Pygments", "Pygments", "colorama"]
+jupyter = ["IPython", "IPython", "attrs", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert"]
+optional = ["IPython", "IPython", "Pygments", "Pygments", "attrs", "colorama", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert", "tomli"]
 optional-strict = ["IPython (==7.10.0)", "IPython (==7.23.1)", "Pygments (==2.0.0)", "Pygments (==2.4.1)", "attrs (==19.2.0)", "colorama (==0.4.1)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.3.0)", "debugpy (==1.6.0)", "ipykernel (==5.2.0)", "ipykernel (==6.0.0)", "ipython-genutils (==0.2.0)", "jedi (==0.16)", "jinja2 (==3.0.0)", "jupyter-client (==6.1.5)", "jupyter-client (==7.0.0)", "jupyter-core (==4.7.0)", "nbconvert (==6.0.0)", "tomli (==0.2.0)"]
 runtime-strict = ["six (==1.11.0)"]
 tests = ["cmake", "codecov", "ninja", "pybind11", "pytest", "pytest", "pytest", "pytest", "pytest", "pytest", "pytest-cov", "pytest-cov", "pytest-cov", "pytest-cov", "scikit-build", "typing"]
@@ -1361,13 +1361,10 @@ python-versions = ">=3.7"
 docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
-[extras]
-docs = ["emoji", "myst-parser", "pygments", "sphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-apidoc", "sphinxcontrib-confluencebuilder", "types-emoji"]
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "efa9be53723238962c6b98538b69af0c36793b3e3abb952347237291e3b728d7"
+content-hash = "21e188dfda4e0b8205a639e6b5cc6c843fbb0e8db173500214d2fda78be8cf33"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,6 @@ importlib-metadata = "^4.12.0"
 structlog-sentry-logger = "^0.17.4"
 typer = {extras = ["all"], version = "^0.6.1"}
 
-# Documentation
-emoji = { version = "^1.7.0", optional = true}
-myst-parser = { version = "^0.18.0", optional = true}
-pygments = { version = "^2.13.0", optional = true}
-sphinx = { version = "^5.1.1", optional = true}
-sphinx-autodoc-typehints = { version = "^1.19.1", optional = true}
-sphinx-rtd-theme = { version = "^1.0.0", optional = true}
-sphinxcontrib-apidoc = { version = "^0.3.0", optional = true}
-sphinxcontrib-confluencebuilder = { version = "^1.9.0", optional = true}
-types-emoji = { version = "^1.7.1", optional = true}
-
 [tool.poetry.dev-dependencies]
 # Type Checking and Data Validation
 mypy = "^0.950" # Static type checker
@@ -83,18 +72,19 @@ pre-commit = "^2.20.0"
 # Documentation
 darglint = "^1.8.1"
 
-[tool.poetry.extras]
-docs = [
-    "emoji", # Render emoji shortcodes
-    "myst-parser",
-    "pygments",
-    "sphinx",
-    "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-apidoc",
-    "sphinxcontrib-confluencebuilder",
-    "types-emoji",
-]
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+emoji = "^1.7.0"
+myst-parser = "^0.18.0"
+pygments = "^2.13.0"
+sphinx = "^5.1.1"
+sphinx-autodoc-typehints = "^1.19.1"
+sphinx-rtd-theme = "^1.0.0"
+sphinxcontrib-apidoc = "^0.3.0"
+sphinxcontrib-confluencebuilder = "^1.9.0"
+types-emoji = "^1.7.1"
 
 #################################################################################
 # Tooling configs                                                               #

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -119,9 +119,9 @@ install-project:
 .PHONY: generate-requirements
 ## Generate project requirements files from `pyproject.toml`
 generate-requirements:
-	poetry export -f requirements.txt --without-hashes > requirements.txt # subset
-	poetry export --with dev -f requirements.txt --without-hashes > requirements-dev.txt # superset w/o docs
-	poetry export --with dev,docs -f requirements.txt --without-hashes > requirements-all.txt # superset
+	poetry export -f requirements.txt --without-hashes --output requirements.txt # subset
+	poetry export --with dev -f requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
+	poetry export --with dev,docs -f requirements.txt --without-hashes --output requirements-all.txt # superset
 
 .PHONY: clean-requirements
 ## Clean generated project requirements files

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -120,8 +120,8 @@ install-project:
 ## Generate project requirements files from `pyproject.toml`
 generate-requirements:
 	poetry export -f requirements.txt --without-hashes > requirements.txt # subset
-	poetry export --dev -f requirements.txt --without-hashes > requirements-dev.txt # superset w/o docs
-	poetry export --with  docs --dev -f requirements.txt --without-hashes > requirements-all.txt # superset
+	poetry export --with dev -f requirements.txt --without-hashes > requirements-dev.txt # superset w/o docs
+	poetry export --with dev,docs -f requirements.txt --without-hashes > requirements-all.txt # superset
 
 .PHONY: clean-requirements
 ## Clean generated project requirements files

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -119,9 +119,9 @@ install-project:
 .PHONY: generate-requirements
 ## Generate project requirements files from `pyproject.toml`
 generate-requirements:
-	poetry export -f requirements.txt --without-hashes --output requirements.txt # subset
-	poetry export --with dev -f requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
-	poetry export --with dev,docs -f requirements.txt --without-hashes --output requirements-all.txt # superset
+	poetry export --format requirements.txt --without-hashes --output requirements.txt # subset
+	poetry export --with dev --format requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
+	poetry export --with dev,docs --format requirements.txt --without-hashes --output requirements-all.txt # superset
 
 .PHONY: clean-requirements
 ## Clean generated project requirements files

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -103,7 +103,7 @@ endif
 .PHONY: install-dependencies
 ## Install Python dependencies specified in `poetry.lock`
 install-dependencies:
-	poetry install --no-interaction --no-root --extras docs -vv
+	poetry install --no-interaction --no-root --with docs -vv
 #{%- if cookiecutter.adr_documentation_support == 'yes' %}
 	# Install node ADR management library
 	poetry run nodeenv --python-virtualenv --jobs=$(NUM_PROCS)
@@ -121,7 +121,7 @@ install-project:
 generate-requirements:
 	poetry export -f requirements.txt --without-hashes > requirements.txt # subset
 	poetry export --dev -f requirements.txt --without-hashes > requirements-dev.txt # superset w/o docs
-	poetry export --extras docs --dev -f requirements.txt --without-hashes > requirements-all.txt # superset
+	poetry export --with  docs --dev -f requirements.txt --without-hashes > requirements-all.txt # superset
 
 .PHONY: clean-requirements
 ## Clean generated project requirements files

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -49,22 +49,6 @@ icontract = "^2.6.1" # Design-by-contract support
 typeguard = "^2.13.3" # Runtime type checker; Note: Mypyc-compiled C-extensions also perform runtime type checking.
 {%- endif %}
 
-# Documentation
-# Specifying documentation dependencies as optional dependencies
-# as a hack until Poetry version >= 1.2 when dependency groups are supported
-# see: python-poetry/poetry#1644
-emoji = { version = "^1.6.3", optional = true}
-{%- if cookiecutter.project_boilerplate_type != 'cli' %}
-importlib-metadata = { version = "^4.11.1", optional = true}
-{%- endif %}
-myst-parser = { version = "^0.17.0", optional = true}
-pygments = { version = "^2.11.2", optional = true}
-sphinx = { version = "^4.4.0", optional = true}
-sphinx-autoapi = { version = "^1.8.4", optional = true}
-sphinx-rtd-theme = { version = "^1.0.0", optional = true}
-sphinxcontrib-confluencebuilder = { version = "^1.7.1", optional = true}
-types-emoji = { version = "^1.2.7", optional = true} # PEP 561 compliant stub package for mypy
-
 # Project-Specific
 python-dotenv = "^0.19.2"
 {%- if cookiecutter.project_boilerplate_type == 'cli' %}
@@ -124,23 +108,21 @@ darglint = "^1.8.1"
 nodeenv = "^1.6.0" # ADR documentation Node dependency
 {%- endif %}
 
-# Specifying documentation dependencies as optional dependencies
-# as a hack until Poetry version >= 1.2 when dependency groups are supported
-# see: python-poetry/poetry#1644
-[tool.poetry.extras]
-docs = [
-    "emoji", # Render emoji shortcodes
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+emoji = "^1.6.3"
 {%- if cookiecutter.project_boilerplate_type != 'cli' %}
-    "importlib-metadata",
+importlib-metadata = "^4.11.1"
 {%- endif %}
-    "myst-parser",
-    "pygments",
-    "sphinx",
-    "sphinx-autoapi",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-confluencebuilder",
-    "types-emoji",
-]
+myst-parser = "^0.17.0"
+pygments = "^2.11.2"
+sphinx = "^4.4.0"
+sphinx-autoapi = "^1.8.4"
+sphinx-rtd-theme = "^1.0.0"
+sphinxcontrib-confluencebuilder = "^1.7.1"
+types-emoji = "^1.2.7" # PEP 561 compliant stub package for mypy
 
 {%- if cookiecutter.project_boilerplate_type != 'none' %}
 [tool.poetry.scripts]


### PR DESCRIPTION
## What
SSIA.

## Why
Introduced in Poetry version `1.2.0`, dependency groups are cleaner and improve compatibility with user projects' dependencies.
- https://python-poetry.org/blog/announcing-poetry-1.2.0/#dependency-groups

> **Note**
>
> Also fixes the broken documentation building workflow since Poetry version `1.2.0` now uninstalls extras dependencies on any install command that doesn't explicitly include them. 
>
> ex.,
> - `poetry install --no-interaction --no-root --extras docs -vv` will install the `docs` extras, 
> - subsequently running `poetry install --no-interaction -vv` will **uninstall** the `docs` extras.