### PR TITLE
👷 Remove Windows from benchmarks suite

### DIFF
--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-publish-benchmarks:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10"]
         library-type: ["pure_python"]
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-publish-benchmarks:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10"]
         library-type: ["pure_python", "c_library"]
 


### PR DESCRIPTION
To fix CI since these have been timing out for a long time. Only spotted in #598 when workflows previously triggered async (to workaround Dependabot not having access to secrets) were recoupled to commits/PRs