### PR TITLE
🚨 Remove deprecated `nbqa` flag

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -73,13 +73,10 @@ repos:
     rev: 1.5.0
     hooks:
       - id: nbqa-black
-        args: [--nbqa-mutate]
         additional_dependencies: [black==22.3.0]
       - id: nbqa-isort
-        args: [--nbqa-mutate]
         additional_dependencies: [isort==5.9.3]
       - id: nbqa-pyupgrade
-        args: [--nbqa-mutate]
         additional_dependencies: [pyupgrade==v2.25.0]
 
   - repo: local


### PR DESCRIPTION
## WHAT
SSIA.

## WHY
Flag `--nbqa-mutate` was deprecated in 1.0.0 and is now unnecessary