### PR TITLE
🚨  Fix security scanning for `CVE-2022-42969`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,8 @@ commands = pre-commit run {posargs} -vv --all-files --color always
 [testenv:security]
 skip_install = true
 deps = safety
-commands = safety check --full-report -r {toxinidir}/requirements-all.txt
+commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
+    --ignore=51457 # CVE-2022-42969
 
 [testenv:docs]
 extras =

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -264,7 +264,8 @@ commands = poetry build
 [testenv:security]
 skip_install = true
 deps = safety
-commands = safety check --full-report -r {toxinidir}/requirements-all.txt
+commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
+    --ignore=51457 # CVE-2022-42969
 
 [testenv:docs]
 extras =


### PR DESCRIPTION
## WHAT
SSIA.

## WHY
Unapplicable to this project. Mostly related to, but tox does not use the affected part of the library.
- ref: https://github.com/tox-dev/tox/issues/2524#issuecomment-1298932829