### PR TITLE
👷  Fix template mutation testing job

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
   test-mutations:
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.10"]
 
     name: Mutation testing
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
## WHAT
Downgrade mutation testing CI job Python version to 3.10

## WHY

Running in Python 3.11 throws transitive dependency errors on mutation testing exit:
```
  File "/app/structlog-sentry-logger/.tox/mutmut/lib/python3
  .11/site-packages/pony/orm/decompiling.py", line 196, in get_instructions
    arg = [code.co_names[oparg]]
```