### PR TITLE
📝 💚  [docs] Remove unused usage page and fix auto-generated header anchors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,6 +78,7 @@ html_show_sourcelink = (
 # Prefix document path to section labels, to use:
 # `path/to/file:heading` instead of just `heading`
 autosectionlabel_prefix_document = True
+myst_heading_anchors = 3
 
 
 def convert_emoji_shortcodes(app: Sphinx, exception: Exception) -> None:

--- a/{{cookiecutter.project_slug}}/docs/source/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/source/conf.py
@@ -112,6 +112,7 @@ autodoc_typehints = "description"  # Show typehints as content of function or me
 # Prefix document path to section labels, to use:
 # `path/to/file:heading` instead of just `heading`
 autosectionlabel_prefix_document = True
+myst_heading_anchors = 3
 
 
 def convert_emoji_shortcodes(app: Sphinx, exception: Exception) -> None:

--- a/{{cookiecutter.project_slug}}/docs/source/index.md
+++ b/{{cookiecutter.project_slug}}/docs/source/index.md
@@ -7,7 +7,6 @@
    :maxdepth: 1
 
    readme
-   {% if cookiecutter.project_boilerplate_type == 'cli' -%} usage {%- endif %}
    API Reference <autoapi/{{cookiecutter.package_name}}/index>
    {% if cookiecutter.project_type == 'package' -%} Developer Reference <autoapi/{{cookiecutter.package_name}}/PATH_TO_HIDDEN_MODULES/index> {%- endif %}
    contributing


### PR DESCRIPTION
## WHAT
SSIA.

Auto-generated header anchors have been broken since [myst-parser version 0.17.0](https://github.com/executablebooks/MyST-Parser/releases/tag/v0.17.0)
- https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#markdown-link-resolution-improvements

## WHY

To clean up and fix documentation building.