### PR TITLE
🔧 Migrate `shfmt` pre-commit hook to canonical repo source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,16 +81,10 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
-  - repo: local
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.5.1-2
     hooks:
-      - id: shfmt
-        name: shfmt
-        minimum_pre_commit_version: 2.17.0
-        language: golang
-        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.1.2]
-        entry: shfmt
-        args: [-w]
-        types: [shell]
+      - id: shfmt # native (requires Go to build)
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.28.0

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -139,16 +139,10 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
-  - repo: local
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.5.1-2
     hooks:
-      - id: shfmt
-        name: shfmt
-        minimum_pre_commit_version: 2.17.0
-        language: golang
-        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.1.2]
-        entry: shfmt
-        args: [-w]
-        types: [shell]
+      - id: shfmt # native (requires Go to build)
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.28.0


### PR DESCRIPTION
## WHAT
SSIA.

## WHY
To simplify `shfmt` pre-commit hook instantiation and usage.
- see: [`shfmt` pre-commit hook ](https://github.com/scop/pre-commit-shfmt)