### PR TITLE
🔧 Migrate to Docker-based shfmt pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,18 +55,6 @@ jobs:
             .tox
           key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Install Go for pre-commit hook (shfmt)
-        run: |
-          GO_TAR=go1.16.linux-amd64.tar.gz && \
-          wget --quiet https://golang.org/dl/$GO_TAR && \
-          sudo tar -C /usr/local -xzf $GO_TAR && \
-          rm $GO_TAR && \
-          export GO111MODULE=on && \
-          export CGO_ENABLED=0 && \
-          export GOOS=linux && \
-          export GOARCH=amd64 && \
-          sudo ln -sf /usr/local/go/bin/go /usr/bin/go
-
       - name: Run static analysis
         run: |
           make pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.5.1-2
     hooks:
-      - id: shfmt # native (requires Go to build)
+      - id: shfmt-docker # Docker image (requires Docker to run)
         args:
           # Formatting options based on Google's shell style guidelines
           # see:

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -55,19 +55,6 @@ jobs:
             .tox
           key: tox-{{ "${{ github.workflow }}" }}-{{ "${{ github.job }}" }}-{{ "${{ runner.os }}" }}-CPython{{ "${{ matrix.python-version }}" }}-{{ "${{ hashFiles('**/poetry.lock') }}" }}
 
-
-      - name: Install Go for pre-commit hook (shfmt)
-        run: |
-          GO_TAR=go1.16.linux-amd64.tar.gz && \
-          wget --quiet https://golang.org/dl/$GO_TAR && \
-          sudo tar -C /usr/local -xzf $GO_TAR && \
-          rm $GO_TAR && \
-          export GO111MODULE=on && \
-          export CGO_ENABLED=0 && \
-          export GOOS=linux && \
-          export GOARCH=amd64 && \
-          sudo ln -sf /usr/local/go/bin/go /usr/bin/go
-
       - name: Run static analysis
         run: |
           make pre-commit

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -150,7 +150,7 @@ repos:
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.5.1-2
     hooks:
-      - id: shfmt # native (requires Go to build)
+      - id: shfmt-docker # Docker image (requires Docker to run)
         args:
           # Formatting options based on Google's shell style guidelines
           # see:


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

To avoid the need for Go as a dev dependency, both locally and in CI.