### PR TITLE
💚 Fix CI for new projects (`tox-gh-actions` versions <3 incompatibility with `tox` versions >3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,11 @@ updates:
       - "dependencies"
       - "python"
     open-pull-requests-limit: 99
+    ignore:
+      - dependency-name: "tox"
+        # For tox, ignore all updates for version 4
+        # until https://github.com/ymyzk/tox-gh-actions/issues/59 is closed
+        versions: ["4.x"]
   # Project dependencies
   - package-ecosystem: pip
     directory: "/{{cookiecutter.project_slug}}"

--- a/{{cookiecutter.project_slug}}/.github/workflows/constraints.txt
+++ b/{{cookiecutter.project_slug}}/.github/workflows/constraints.txt
@@ -1,4 +1,4 @@
 pip==22.3.1
 poetry==1.3.1
-tox==4.0.8
+tox==3.27.1
 tox-gh-actions==2.12.0


### PR DESCRIPTION
## WHAT

- Fixes CI for new projects caused by incompatible versions of `tox` and `tox-gh-actions` (introduced in #848).
- Temporarily pins @dependabot `tox` updates to version <4 for the template project's GitHub Actions until a compatible version of `tox-gh-actions` is released (see ymyzk/tox-gh-actions#59).

## WHY

To propagate this fix to both the example project as well as any new projects.
