### PR TITLE
👷 Patch deprecated GitHub Actions `set-output` commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |
-          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> $GITHUB_OUTPUT
 
       - name: Detect and tag new version
         id: detect-new-version-tag
@@ -52,7 +52,7 @@ jobs:
           git checkout "${BRANCH_NAME}"
           CURRENT_COMMIT_VER=$(make get-project-version-number)
           if [[ "${PARENT_COMMIT_VER}" != "${CURRENT_COMMIT_VER}" ]]; then
-            echo "::set-output name=tag::${CURRENT_COMMIT_VER}"
+            echo "tag=${CURRENT_COMMIT_VER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Bump version for developmental release
@@ -63,7 +63,7 @@ jobs:
           VERSION=$(make get-project-version-number) &&
           DEV_VERSION="${VERSION}.dev.$(date +%s)" &&
           poetry version "${DEV_VERSION}" &&
-          echo "::set-output name=version::${DEV_VERSION}"
+          echo "version=${DEV_VERSION}" >> $GITHUB_OUTPUT
 
 
   # Release notes publication ----------------------

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
@@ -72,11 +72,11 @@ jobs:
             make "tox-${TOX_TESTENV}"
 
             BENCHMARK_FILE=$(find .benchmarks -maxdepth 2 -type f -name "*.json" | sort  --version-sort --reverse | tail -n 1)
-            echo "::set-output name=benchmark_file_path::${BENCHMARK_FILE}"
+            echo "benchmark_file_path=${BENCHMARK_FILE}" >> $GITHUB_OUTPUT
 
             ENV_DIR_NAME=$(basename "${BENCHMARK_FILE%/*}" | tr '-' '/')
             NAMESPACED_TARGET_OUTPUT_DIR="${ENV_DIR_NAME}/{{ "${{ matrix.library-type }}" }}"
-            echo "::set-output name=target_output_dir::${NAMESPACED_TARGET_OUTPUT_DIR}"
+            echo "target_output_dir=${NAMESPACED_TARGET_OUTPUT_DIR}" >> $GITHUB_OUTPUT
 
       - name: Store the environment-specific benchmarks
         uses: actions/upload-artifact@v3.1.0

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |
-          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> $GITHUB_OUTPUT
 
       - name: Detect new version tag
         id: detect-new-version-tag
@@ -54,7 +54,7 @@ jobs:
           git checkout "${BRANCH_NAME}"
           CURRENT_COMMIT_VER=$(make get-project-version-number)
           if [[ "${PARENT_COMMIT_VER}" != "${CURRENT_COMMIT_VER}" ]]; then
-            echo "::set-output name=tag::${CURRENT_COMMIT_VER}"
+            echo "tag=${CURRENT_COMMIT_VER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Bump version for developmental release
@@ -65,7 +65,7 @@ jobs:
           VERSION=$(make get-project-version-number) &&
           DEV_VERSION="${VERSION}.dev.$(date +%s)" &&
           poetry version "${DEV_VERSION}" &&
-          echo "::set-output name=version::${DEV_VERSION}"
+          echo "version=${DEV_VERSION}" >> $GITHUB_OUTPUT
 
 
   {%- if cookiecutter.project_type == 'package' %}
@@ -123,14 +123,14 @@ jobs:
         run: |
           VERSION={{ "${{ needs.get-tag-xor-dev-version.outputs.dev-version }}" }}
           poetry version "${VERSION}"
-          echo "::set-output name=is_testing::true"
+          echo "is_testing=true" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Log package version
         id: log-package-version
         run: |
           VERSION=$(make get-project-version-number)
-          echo "::set-output name=version::${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Build package
@@ -283,7 +283,7 @@ jobs:
         run: |
           CI_TAGGED_IMG=$(echo -n $(make get-docker-img-strong-version-tag get-project-version-number) | tr ' ' '-')
           CANONICAL_TAGGED_IMGS=$(echo -n $(make get-docker-img-strong-version-tag get-docker-img-latest-tag) | tr ' ' ',')
-          echo "::set-output name=tagged_images::${CI_TAGGED_IMG},${CANONICAL_TAGGED_IMGS}"
+          echo "tagged_images=${CI_TAGGED_IMG},${CANONICAL_TAGGED_IMGS}" >> $GITHUB_OUTPUT
 
       - name: Build and push container image
         id: docker_build


### PR DESCRIPTION
## WHAT 
SSIA.

## WHY
To fix deprecation warnings and prevent CI breakage once `set-output` is fully deprecated.
- see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/