### PR TITLE
💚 Fix benchmarks not being published on pushes to `master`

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish_benchmarks.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Store benchmark result
         uses: TeoZosa/github-action-benchmark@v1.8.2
-        if: github.event.workflow_run.head_branch == 'master'
+        if: github.ref == 'refs/heads/master'
         with:
           tool: 'pytest'
           benchmark-data-dir-path: dev/bench/{{ "${{ steps.performance-testing.outputs.target_output_dir }}" }}


### PR DESCRIPTION
## WHAT
SSIA.

## WHY
Benchmarks publishing has been broken since #598.