### PR TITLE
👷  Group `build` PRs in release notes under "Continuous Integration Build System" label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,8 +12,9 @@ categories:
     label: "performance"
   - title: ":white_check_mark: Testing"
     label: "testing"
-  - title: ":construction_worker: Continuous Integration"
+  - title: ":construction_worker: Continuous Integration Build System"
     labels:
+      - "build"
       - "ci"
       - "github_actions"
   - title: ":memo: Documentation"
@@ -21,9 +22,7 @@ categories:
   - title: ":recycle: Refactoring"
     label: "refactoring"
   - title: ":package: Dependencies"
-    labels:
-      - "dependencies"
-      - "build"
+    label: "dependencies"
 template: |
   ## Changes
 

--- a/{{cookiecutter.project_slug}}/.github/release-drafter.yml
+++ b/{{cookiecutter.project_slug}}/.github/release-drafter.yml
@@ -12,8 +12,9 @@ categories:
     label: "performance"
   - title: ":white_check_mark: Testing"
     label: "testing"
-  - title: ":construction_worker: Continuous Integration"
+  - title: ":construction_worker: Continuous Integration Build System"
     labels:
+      - "build"
       - "ci"
       - "github_actions"
   - title: ":memo: Documentation"
@@ -21,9 +22,7 @@ categories:
   - title: ":recycle: Refactoring"
     label: "refactoring"
   - title: ":package: Dependencies"
-    labels:
-      - "dependencies"
-      - "build"
+    label: "dependencies"
 template: |
   ## Changes
 


### PR DESCRIPTION
## WHAT
SSIA. 

## WHY
For better logical grouping; these were previously grouped under the "Dependency" label despite being mostly orthogonal to dependency-related changes.