### PR TITLE
🔧  Add Python 3.10 & 3.11 to benchmark suite

### DIFF
--- a/{{cookiecutter.project_slug}}/.makefile/test.mk
+++ b/{{cookiecutter.project_slug}}/.makefile/test.mk
@@ -45,7 +45,7 @@ performance-benchmarks:
 .PHONY: performance-benchmarks-%
 # Run library-specific (viz. Python or C) performance benchmark tests
 performance-benchmarks-%:
-	$(MAKE) tox-"py3{8,9}-benchmark-$*"
+	$(MAKE) tox-"py3{8,9,10,11}-benchmark-$*"
 
 # Mutation testing modifies the code in small ways that should produce incorrect semantics
 # If a test suite is sufficiently strong, this "mutated" code should caught by the suite,


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

Follow-up to:
- #816 
- #817  