### PR TITLE
📌 Unpin `nbqa` deps

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -79,7 +79,6 @@ repos:
     rev: 1.5.3
     hooks:
       - id: nbqa-black
-        additional_dependencies: [black==22.10.0]
       - id: nbqa-isort
       - id: nbqa-pyupgrade
 

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -83,7 +83,6 @@ repos:
       - id: nbqa-isort
         additional_dependencies: [isort==5.10.1]
       - id: nbqa-pyupgrade
-        additional_dependencies: [pyupgrade==v3.2.2]
 
   - repo: local
     hooks:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -81,7 +81,6 @@ repos:
       - id: nbqa-black
         additional_dependencies: [black==22.10.0]
       - id: nbqa-isort
-        additional_dependencies: [isort==5.10.1]
       - id: nbqa-pyupgrade
 
   - repo: local


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

Version pins are gratuitous and introduce additional maintenance burden. 
