### PR TITLE
🏗️ Migrate linters to `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,19 +58,6 @@ repos:
         args: [--cache-dir=/dev/null, --config-file=pyproject.toml]
         types: [python]
 
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        language: system
-        # False-positives from cookiecutter Jinja2 template syntax =>
-        # print output but always succeed.
-        # see: https://stackoverflow.com/a/59745587
-        verbose: true
-        entry: bash -c '.tox/precommit/bin/pylint "$@" || true' --
-        args: [--rcfile=pyproject.toml]
-        types: [python]
-
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,12 +54,6 @@ repos:
       - id: script-must-have-extension
       - id: script-must-not-have-extension
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.220
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,16 +21,6 @@ repos:
       - id: detect-secrets
         exclude: poetry.lock
 
-  - repo: https://github.com/flakeheaven/flakeheaven
-    rev: 3.0.0
-    hooks:
-      - id: flakeheaven
-        # False-positives from cookiecutter Jinja2 template syntax =>
-        # print output but always succeed.
-        # see: https://stackoverflow.com/a/59745587
-        verbose: true
-        entry: bash -c 'flakeheaven lint "$@" || true' --
-
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,11 +38,6 @@ repos:
         name: hadolint
         args: [--ignore=DL4003]
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,16 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.220
+    hooks:
+      - id: ruff
+        # False-positives from cookiecutter Jinja2 template syntax =>
+        # print output but always succeed.
+        # see: https://stackoverflow.com/a/59745587
+        verbose: true
+        entry: bash -c 'ruff "$@" || true' --
+
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.8.0
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,22 +18,6 @@ python-versions = ">=3.6"
 python-dateutil = ">=2.7.0"
 
 [[package]]
-name = "astroid"
-version = "2.12.12"
-description = "An abstract syntax tree for Python with inference support."
-category = "dev"
-optional = false
-python-versions = ">=3.7.2"
-
-[package.dependencies]
-lazy-object-proxy = ">=1.4.0"
-typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
-wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
-    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
-]
-
-[[package]]
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
@@ -213,17 +197,6 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
-name = "dill"
-version = "0.3.4"
-description = "serialize all of python"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*"
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
-
-[[package]]
 name = "distlib"
 version = "0.3.4"
 description = "Distribution utilities"
@@ -387,20 +360,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "isort"
-version = "5.10.1"
-description = "A Python utility / library to sort Python imports."
-category = "dev"
-optional = false
-python-versions = ">=3.6.1,<4.0"
-
-[package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
 name = "jinja2"
 version = "3.0.3"
 description = "A very fast and expressive template engine."
@@ -425,14 +384,6 @@ python-versions = "*"
 [package.dependencies]
 arrow = "*"
 jinja2 = "*"
-
-[[package]]
-name = "lazy-object-proxy"
-version = "1.7.1"
-description = "A fast and thorough lazy object proxy."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
 
 [[package]]
 name = "markdown-it-py"
@@ -462,14 +413,6 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=3.7"
-
-[[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "mdit-py-plugins"
@@ -654,29 +597,6 @@ python-versions = ">=3.6"
 
 [package.extras]
 plugins = ["importlib-metadata"]
-
-[[package]]
-name = "pylint"
-version = "2.15.5"
-description = "python code static checker"
-category = "dev"
-optional = false
-python-versions = ">=3.7.2"
-
-[package.dependencies]
-astroid = ">=2.12.12,<=2.14.0-dev0"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = ">=0.2"
-isort = ">=4.2.5,<6"
-mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-tomlkit = ">=0.10.1"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-spelling = ["pyenchant (>=3.2,<4.0)"]
-testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyparsing"
@@ -1160,14 +1080,6 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "tomlkit"
-version = "0.11.0"
-description = "Style preserving TOML library"
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[[package]]
 name = "tox"
 version = "3.27.1"
 description = "tox is a generic virtualenv management and test command line tool"
@@ -1257,14 +1169,6 @@ docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sp
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
 [[package]]
-name = "wrapt"
-version = "1.14.1"
-description = "Module for decorators, wrappers and monkey patching."
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[[package]]
 name = "xdoctest"
 version = "1.1.0"
 description = "A rewrite of the builtin doctest module"
@@ -1301,7 +1205,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.12"
-content-hash = "b901b4e537066dd168dac0b48e77e3397e0ce963491297cb5d9d433cbbb06f8a"
+content-hash = "2839281b55039d3bec2e666c465e6de2d60c00a01acafb4c52366bcaa9d55e6d"
 
 [metadata.files]
 alabaster = [
@@ -1311,10 +1215,6 @@ alabaster = [
 arrow = [
     {file = "arrow-1.2.2-py3-none-any.whl", hash = "sha256:d622c46ca681b5b3e3574fcb60a04e5cc81b9625112d5fb2b44220c36c892177"},
     {file = "arrow-1.2.2.tar.gz", hash = "sha256:05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b"},
-]
-astroid = [
-    {file = "astroid-2.12.12-py3-none-any.whl", hash = "sha256:72702205200b2a638358369d90c222d74ebc376787af8fb2f7f2a86f7b5cc85f"},
-    {file = "astroid-2.12.12.tar.gz", hash = "sha256:1c00a14f5a3ed0339d38d2e2e5b74ea2591df5861c0936bb292b84ccf3a78d83"},
 ]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
@@ -1443,10 +1343,6 @@ darglint = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
 ]
-dill = [
-    {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
-    {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
-]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
@@ -1502,10 +1398,6 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-isort = [
-    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
-    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
-]
 jinja2 = [
     {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
@@ -1513,45 +1405,6 @@ jinja2 = [
 jinja2-time = [
     {file = "jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40"},
     {file = "jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"},
-]
-lazy-object-proxy = [
-    {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win32.whl", hash = "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win32.whl", hash = "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
-    {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.0.1.tar.gz", hash = "sha256:7b5c153ae1ab2cde00a33938bce68f3ad5d68fbe363f946de7d28555bed4e08a"},
@@ -1598,10 +1451,6 @@ markupsafe = [
     {file = "MarkupSafe-2.1.0-cp39-cp39-win32.whl", hash = "sha256:e6f7f3f41faffaea6596da86ecc2389672fa949bd035251eab26dc6697451d05"},
     {file = "MarkupSafe-2.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:b8811d48078d1cf2a6863dafb896e68406c5f513048451cd2ded0473133473c7"},
     {file = "MarkupSafe-2.1.0.tar.gz", hash = "sha256:80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f"},
-]
-mccabe = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mdit-py-plugins = [
     {file = "mdit-py-plugins-0.3.1.tar.gz", hash = "sha256:3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441"},
@@ -1723,10 +1572,6 @@ py-cpuinfo = [
 pygments = [
     {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
     {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
-]
-pylint = [
-    {file = "pylint-2.15.5-py3-none-any.whl", hash = "sha256:c2108037eb074334d9e874dc3c783752cc03d0796c88c9a9af282d0f161a1004"},
-    {file = "pylint-2.15.5.tar.gz", hash = "sha256:3b120505e5af1d06a5ad76b55d8660d44bf0f2fc3c59c2bdd94e39188ee3a4df"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
@@ -1975,10 +1820,6 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-tomlkit = [
-    {file = "tomlkit-0.11.0-py3-none-any.whl", hash = "sha256:0f4050db66fd445b885778900ce4dd9aea8c90c4721141fde0d6ade893820ef1"},
-    {file = "tomlkit-0.11.0.tar.gz", hash = "sha256:71ceb10c0eefd8b8f11fe34e8a51ad07812cb1dc3de23247425fbc9ddc47b9dd"},
-]
 tox = [
     {file = "tox-3.27.1-py2.py3-none-any.whl", hash = "sha256:f52ca66eae115fcfef0e77ef81fd107133d295c97c52df337adedb8dfac6ab84"},
     {file = "tox-3.27.1.tar.gz", hash = "sha256:b2a920e35a668cc06942ffd1cf3a4fb221a4d909ca72191fb6d84b0b18a7be04"},
@@ -2002,72 +1843,6 @@ urllib3 = [
 virtualenv = [
     {file = "virtualenv-20.13.2-py2.py3-none-any.whl", hash = "sha256:e7b34c9474e6476ee208c43a4d9ac1510b041c68347eabfe9a9ea0c86aa0a46b"},
     {file = "virtualenv-20.13.2.tar.gz", hash = "sha256:01f5f80744d24a3743ce61858123488e91cb2dd1d3bdf92adaf1bba39ffdedf0"},
-]
-wrapt = [
-    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
-    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
-    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
-    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
-    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
-    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
-    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
-    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
-    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
-    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
 ]
 xdoctest = [
     {file = "xdoctest-1.1.0-py3-none-any.whl", hash = "sha256:da330c4dacee51f3c785820bc743188fb6f7c64c5fa1c54bff8836b3cf23d69b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,22 @@ xfail_strict = true
 testpaths = ["tests",]
 norecursedirs = [".*", "*.egg", "build", "dist",]
 
+[tool.ruff]
+line-length = 120
+
+ignore = [
+    # pycodestyle:
+    "E501", # Line too long (covered by Black)
+]
+
+fix = true
+
+# Group violations by containing file.
+format = "grouped"
+
+# By default, always show source code snippets.
+show-source = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,6 @@ tox = "^3.27.1"
 # Linting
 ## Code formatting
 black = "^22.10.0" # see: https://black.readthedocs.io/en/stable/editor_integration.html
-## Code quality
-pylint = "^2.15.5"
 ## Automation and management
 pre-commit = "^2.20.0"
 
@@ -120,24 +118,6 @@ show_column_numbers = true
 show_error_context = true
 show_error_codes = true
 
-[tool.pylint.basic]
-good-names-rgxs = ["^Test_.*$"]
-
-[tool.pylint.messages_control]
-disable = [
-  # Explicitly document only as needed
-  "missing-module-docstring",
-  "missing-class-docstring",
-  "missing-function-docstring",
-  # Black & Flake8 purview
-  "line-too-long",
-  "c-extension-no-member",
-]
-
-[tool.pylint.similarities]
-# Ignore imports when computing similarities.
-ignore-imports = "yes"
-
 [tool.pytest.ini_options]
 addopts = ["-rfsxX", "-l", "--tb=short", "--strict-markers", "-vv", "--emoji", "--xdoctest"]
 xfail_strict = true
@@ -149,6 +129,7 @@ line-length = 120
 
 select = [
     "I", # isort
+    "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,6 @@ show_source = true
 
 # list of plugins and rules for them
 [tool.flakeheaven.plugins]
-# include everything in pyflakes except F401
-pyflakes = ["+*", "-F401"]
 # include everything in pycodestyle except what Black covers
 pycodestyle = ["+*",
     "-E203", # Whitespace before ":"
@@ -126,6 +124,7 @@ norecursedirs = [".*", "*.egg", "build", "dist",]
 line-length = 120
 
 select = [
+    "F", # Pyflakes
     "C90", # McCabe
     "I", # isort
     "PLC", "PLE", "PLR", "PLW", # Pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ select = [
     "E", "W", # pycodestyle
     "C90", # McCabe
     "I", # isort
+    "UP", # pyupgrade
     "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
 
@@ -126,6 +127,10 @@ format = "grouped"
 
 # By default, always show source code snippets.
 show-source = true
+
+# Assume Python 3.8
+# Note: helps prevent breaking autofixes from, e.g., pyupgrade
+target-version = "py38"
 
 [tool.ruff.isort]
 # Note: Ruff implicitly uses `profile = "black"`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,11 +113,6 @@ pycodestyle = ["+*",
     "-W503"  # Line break occurred before a binary operator <- this is now considered best practice by PEP 8
 ]
 
-[tool.isort]
-profile = "black"
-atomic = true
-combine_as_imports = true
-
 [mypy]
 ignore_missing_imports = true
 pretty = true
@@ -152,6 +147,10 @@ norecursedirs = [".*", "*.egg", "build", "dist",]
 [tool.ruff]
 line-length = 120
 
+select = [
+    "I", # isort
+]
+
 ignore = [
     # pycodestyle:
     "E501", # Line too long (covered by Black)
@@ -164,6 +163,10 @@ format = "grouped"
 
 # By default, always show source code snippets.
 show-source = true
+
+[tool.ruff.isort]
+# Note: Ruff implicitly uses `profile = "black"`
+combine-as-imports = true
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,15 +98,6 @@ format = "grouped"
 # show line of source code in output
 show_source = true
 
-# list of plugins and rules for them
-[tool.flakeheaven.plugins]
-# include everything in pycodestyle except what Black covers
-pycodestyle = ["+*",
-    "-E203", # Whitespace before ":"
-    "-E501", # Line too long (82 > 78 characters)
-    "-W503"  # Line break occurred before a binary operator <- this is now considered best practice by PEP 8
-]
-
 [mypy]
 ignore_missing_imports = true
 pretty = true
@@ -125,6 +116,7 @@ line-length = 120
 
 select = [
     "F", # Pyflakes
+    "E", "W", # pycodestyle
     "C90", # McCabe
     "I", # isort
     "PLC", "PLE", "PLR", "PLW", # Pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,6 @@ show_source = true
 
 # list of plugins and rules for them
 [tool.flakeheaven.plugins]
-# cyclomatic complexity (https://github.com/PyCQA/mccabe)
-mccabe = ["+*"]
 # include everything in pyflakes except F401
 pyflakes = ["+*", "-F401"]
 # include everything in pycodestyle except what Black covers
@@ -128,6 +126,7 @@ norecursedirs = [".*", "*.egg", "build", "dist",]
 line-length = 120
 
 select = [
+    "C90", # McCabe
     "I", # isort
     "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
@@ -148,6 +147,10 @@ show-source = true
 [tool.ruff.isort]
 # Note: Ruff implicitly uses `profile = "black"`
 combine-as-imports = true
+
+[tool.ruff.mccabe]
+# cyclomatic complexity (https://github.com/PyCQA/mccabe)
+max-complexity = 10
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,14 +90,6 @@ types-emoji = "^1.7.1"
 [tool.black]
 line-length = 120
 
-[tool.flakeheaven]
-# specify any flake8 options
-exclude = [".*"] # Ignore dotfiles
-# make output nice
-format = "grouped"
-# show line of source code in output
-show_source = true
-
 [mypy]
 ignore_missing_imports = true
 pretty = true

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,6 @@ deps =
     pre-commit
     # Pre-commit hooks that rely on finding their executables in the `.tox/precommit/bin`
     mypy
-    pylint
     # Dependencies that are imported in source code and therefore needed for above pre-commit hook execution
     icontract
     pytest

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -99,21 +99,6 @@ repos:
         args: [--cache-dir=/dev/null, --config-file=pyproject.toml]
         language: system
         types: [jupyter]
-
-  # Note: submit docs for this to nbqa?
-  # ex. https://nbqa.readthedocs.io/en/latest/pre-commit.html
-  # referencing:
-  #   [Remove pylint config E0401 and make pylint a local pre-commit hook #229](https://github.com/nbQA-dev/nbQA/pull/229/files)
-
-  # E0401: import-error
-  - repo: local
-    hooks:
-      - id: nbqa-pylint
-        name: nbqa-pylint
-        description: "Run tox env `pylint` on a Jupyter Notebook"
-        entry: .tox/precommit/bin/nbqa pylint
-        language: system
-        types: [jupyter]
   # {%- endif %}
 
   - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -53,11 +53,6 @@ repos:
       - id: interrogate
         args: [-vv, --config=pyproject.toml]
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.2
     hooks:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -101,12 +101,6 @@ repos:
       - id: script-must-have-extension
       - id: script-must-not-have-extension
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.220
     hooks:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -68,7 +68,6 @@ repos:
     rev: 1.6.1
     hooks:
       - id: nbqa-black
-      - id: nbqa-pyupgrade
       - id: nbqa-ruff
 
   - repo: local

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -74,7 +74,6 @@ repos:
     rev: 1.6.1
     hooks:
       - id: nbqa-black
-      - id: nbqa-isort
       - id: nbqa-pyupgrade
       - id: nbqa-ruff
 

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
 
   # {%- if cookiecutter.jupyter_notebook_project != 'no' %}
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.5.3
+    rev: 1.6.1
     hooks:
       - id: nbqa-black
       - id: nbqa-isort

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -142,6 +142,11 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.220
+    hooks:
+      - id: ruff
+
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.8.0
     hooks:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
         exclude_types: [jupyter]
         # {%- endif %}
 
-  - repo: https://github.com/flakeheaven/flakeheaven
-    rev: 3.2.1
-    hooks:
-      - id: flakeheaven
-        exclude_types: [jupyter]
-
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -81,6 +81,7 @@ repos:
       - id: nbqa-black
       - id: nbqa-isort
       - id: nbqa-pyupgrade
+      - id: nbqa-ruff
 
   - repo: local
     hooks:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -116,15 +116,6 @@ repos:
         types: [jupyter]
   # {%- endif %}
 
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        language: system
-        entry: .tox/precommit/bin/pylint
-        args: [--rcfile=pyproject.toml]
-        types: [python]
-
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -199,11 +199,6 @@ fail-under = 0 # adjust `fail-under` value as quality standards permit
 whitelist-regex = []
 color = true
 
-[tool.isort]
-profile = "black"
-atomic = true
-combine_as_imports = true
-
 [tool.mypy]
 disallow_untyped_defs = true
 files = "**/*.py"
@@ -252,6 +247,10 @@ norecursedirs = [".*", "*.egg", "build", "dist",]
 [tool.ruff]
 line-length = 120
 
+select = [
+    "I", # isort
+]
+
 ignore = [
     # pycodestyle:
     "E501", # Line too long (covered by Black)
@@ -264,6 +263,10 @@ format = "grouped"
 
 # By default, always show source code snippets.
 show-source = true
+
+[tool.ruff.isort]
+# Note: Ruff implicitly uses `profile = "black"`
+combine-as-imports = true
 
 [build-system]
 requires = ["poetry-core>=1.0.0",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -166,21 +166,6 @@ format = "grouped"
 # show line of source code in output
 show_source = true
 
-# list of plugins and rules for them
-[tool.flakeheaven.plugins]
-# include everything in pycodestyle except what Black covers
-pycodestyle = ["+*",
-    "-E203", # Whitespace before ":"
-    "-E501", # Line too long (82 > 78 characters)
-    "-W503",  # Line break occurred before a binary operator <- this is now considered best practice by PEP 8
-#{%- if cookiecutter.jupyter_notebook_project != 'no' %}
-    # Ignore errors resulting from Jupyter notebook to Python module portability formatting
-    "-E265", # block comment should start with '# '
-    # Ignore errors resulting from Jupyter notebook-style programming
-    "-E402", # module level import not at top of file
-#{%- endif %}
-]
-
 [tool.interrogate]
 ignore-init-method = true
 ignore-init-module = true
@@ -229,6 +214,7 @@ line-length = 120
 
 select = [
     "F", # Pyflakes
+    "E", "W", # pycodestyle
     "C90", # McCabe
     "I", # isort
     "PLC", "PLE", "PLR", "PLW", # Pylint

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -209,6 +209,7 @@ select = [
     "E", "W", # pycodestyle
     "C90", # McCabe
     "I", # isort
+    "UP", # pyupgrade
     "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
 
@@ -224,6 +225,10 @@ format = "grouped"
 
 # By default, always show source code snippets.
 show-source = true
+
+# Assume Python 3.8
+# Note: helps prevent breaking autofixes from, e.g., pyupgrade
+target-version = "py38"
 
 [tool.ruff.isort]
 # Note: Ruff implicitly uses `profile = "black"`

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -168,8 +168,6 @@ show_source = true
 
 # list of plugins and rules for them
 [tool.flakeheaven.plugins]
-# include everything in pyflakes except F401
-pyflakes = ["+*", "-F401"]
 # include everything in pycodestyle except what Black covers
 pycodestyle = ["+*",
     "-E203", # Whitespace before ":"
@@ -230,6 +228,7 @@ norecursedirs = [".*", "*.egg", "build", "dist",]
 line-length = 120
 
 select = [
+    "F", # Pyflakes
     "C90", # McCabe
     "I", # isort
     "PLC", "PLE", "PLR", "PLW", # Pylint

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -158,14 +158,6 @@ skip = [
     "docs/source/.env",
 ]
 
-[tool.flakeheaven]
-# specify any flake8 options
-exclude = [".*"] # Ignore dotfiles
-# make output nice
-format = "grouped"
-# show line of source code in output
-show_source = true
-
 [tool.interrogate]
 ignore-init-method = true
 ignore-init-module = true

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -168,8 +168,6 @@ show_source = true
 
 # list of plugins and rules for them
 [tool.flakeheaven.plugins]
-# cyclomatic complexity (https://github.com/PyCQA/mccabe)
-mccabe = ["+*"]
 # include everything in pyflakes except F401
 pyflakes = ["+*", "-F401"]
 # include everything in pycodestyle except what Black covers
@@ -232,6 +230,7 @@ norecursedirs = [".*", "*.egg", "build", "dist",]
 line-length = 120
 
 select = [
+    "C90", # McCabe
     "I", # isort
     "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
@@ -252,6 +251,10 @@ show-source = true
 [tool.ruff.isort]
 # Note: Ruff implicitly uses `profile = "black"`
 combine-as-imports = true
+
+[tool.ruff.mccabe]
+# cyclomatic complexity (https://github.com/PyCQA/mccabe)
+max-complexity = 10
 
 [build-system]
 requires = ["poetry-core>=1.0.0",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -249,6 +249,22 @@ markers = [
 testpaths = ["tests",]
 norecursedirs = [".*", "*.egg", "build", "dist",]
 
+[tool.ruff]
+line-length = 120
+
+ignore = [
+    # pycodestyle:
+    "E501", # Line too long (covered by Black)
+]
+
+fix = true
+
+# Group violations by containing file.
+format = "grouped"
+
+# By default, always show source code snippets.
+show-source = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0",
     #{%- if cookiecutter.jupyter_notebook_project != 'yes' %}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -94,8 +94,6 @@ tox-wheel = "^1.0.0"
 # Linting
 ## Code formatting
 black = "^22.10.0" # see: https://black.readthedocs.io/en/stable/editor_integration.html
-## Code quality
-pylint = "^2.15.6"
 ## Automation and management
 pre-commit = "^2.20.0"
 
@@ -208,19 +206,9 @@ show_column_numbers = true
 show_error_context = true
 show_error_codes = true
 
-[tool.pylint.basic]
-good-names-rgxs = ["^Test_.*$"]
-
+#{%- if cookiecutter.jupyter_notebook_project != 'no' %}
 [tool.pylint.messages_control]
 disable = [
-  # Explicitly document only as needed
-  "missing-module-docstring",
-  "missing-class-docstring",
-  "missing-function-docstring",
-  # Black & Flake8 purview
-  "line-too-long",
-  "c-extension-no-member",
-#{%- if cookiecutter.jupyter_notebook_project != 'no' %}
   # Ignore errors resulting from Jupyter notebook-style programming
   "invalid-name",
   "redefined-outer-name",
@@ -228,12 +216,8 @@ disable = [
   "ungrouped-imports",
   "wrong-import-order",
   "wrong-import-position",
-#{%- endif %}
 ]
-
-[tool.pylint.similarities]
-# Ignore imports when computing similarities.
-ignore-imports = "yes"
+#{%- endif %}
 
 [tool.pytest.ini_options]
 addopts = ["-rfsxX", "-l", "--tb=short", "--strict-markers", "-vv", "--emoji", "--xdoctest"]
@@ -249,6 +233,7 @@ line-length = 120
 
 select = [
     "I", # isort
+    "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
 
 ignore = [

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -227,7 +227,6 @@ deps =
 {%- if cookiecutter.jupyter_notebook_project != 'no' %}
     nbqa
 {%- endif %}
-    pylint
     # Dependencies that are imported in source code and therefore needed for above pre-commit hook execution
     emoji
     hypothesis


### PR DESCRIPTION
## WHAT

### cookiecutter

Adds [`ruff`](https://github.com/charliermarsh/ruff) as a pre-commit hook and migrates the below existing linters: 
- isort
- Pylint
- McCabe
- Pyflakes
- pycodestyle
- FlakeHeaven
- pyupgrade

### Project Template

Adds [`ruff`](https://github.com/charliermarsh/ruff) and [`nbqa-ruff`](https://github.com/charliermarsh/ruff#does-ruff-support-jupyter-notebooks) as a pre-commit hook and migrates the below existing linters: 
- isort
- Pylint
- McCabe
- Pyflakes
- pycodestyle
- FlakeHeaven
- pyupgrade
- nbqa-isort
- nbqa-pylint
- nbqa-pyupgrade

## WHY

To significantly reduce linting time for the above-mentioned linters (`11.24s` => `0.04s`) and automate more fixes.